### PR TITLE
Patch CompInspectStringExtra to better reflect when a waste/biopack is safe from deterioration.

### DIFF
--- a/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Harmony/CompDissolution_CompInspectStringExtra.cs
+++ b/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Harmony/CompDissolution_CompInspectStringExtra.cs
@@ -1,0 +1,59 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System.Reflection;
+using Verse;
+using System.Reflection.Emit;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using System;
+using Verse.AI;
+using RimWorld.Planet;
+using System.Text;
+
+// Patches the CompInspectStringExtra method of the CompDissolution class.
+// Patch makes the Inspect String of a Wastepack/Biopack read "Protected (won't dissolve)." when inside of the Waste Crate.
+
+// Godspeed, and thanks for the wonderful mod(s)! - Negitive
+
+namespace VanillaRecyclingExpanded
+{
+
+
+
+    [HarmonyPatch(typeof(CompDissolution))]
+    [HarmonyPatch("CompInspectStringExtra", MethodType.Normal)]
+    public static class VanillaRecyclingExpanded_CompDissolution_CompInspectStringExtra_Patch
+    {
+        [HarmonyPostfix]
+        public static void InspectStringInformOfProtection(CompDissolution __instance, ref string __result)
+
+        {
+            if (__instance.parent.StoringThing() is Building_WasteCrate) {
+
+                StringBuilder stringBuilder = new StringBuilder();
+
+                stringBuilder.Append("VRecyclingE_DissolutionWasteCrate".Translate());
+
+                __result = stringBuilder.ToString();
+
+
+            }
+
+
+
+        }
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/VanillaRecyclingExpanded.csproj
+++ b/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/VanillaRecyclingExpanded.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Comps\Properties\CompProperties_ToxGasOnDestroyed.cs" />
     <Compile Include="DefOfs\InternalDefOf.cs" />
     <Compile Include="Defs\TerrainConversionsDef.cs" />
+    <Compile Include="Harmony\CompDissolution_CompInspectStringExtra.cs" />
     <Compile Include="Harmony\TerrainDef_IsCarpet.cs" />
     <Compile Include="Harmony\CompDissolution_CanDissolveNow.cs" />
     <Compile Include="Harmony\HarmonyInstance.cs" />

--- a/Languages/English/Keyed/Misc.xml
+++ b/Languages/English/Keyed/Misc.xml
@@ -7,6 +7,7 @@
 	<VRecyclingE_Leaking>This reactive isotopack is leaking radiation</VRecyclingE_Leaking>
 	<VRecyclingE_DurationUntilNextProcess>Time until {1} {0_labelPlural} are ready</VRecyclingE_DurationUntilNextProcess>
 	<VRecyclingE_ContainedThings>Contained {0}</VRecyclingE_ContainedThings>
+	<VRecyclingE_DissolutionWasteCrate>Protected (won't dissolve).</VRecyclingE_DissolutionWasteCrate>
 
 
 


### PR DESCRIPTION
I've added a new file "CompDissolution_CompInspectStringExtra.cs" which contains a patch for the CompInspectStringExtra method of the CompDissolution class.

The patch simply makes it so that when you select a pack stored in a Waste Crate, it's tooltip (Inspect String) reads "Protected (won't dissolve)" instead of incorrectly stating that a pack will dissolve every X days.

I have attempted to emulate your coding practices and formatting to ensure ease of merging on your part, but this is not a subject of which I have a lot of experience, so please forgive any issues that I may have missed when attempting to ensure this was as smooth a transition as possible.

Finally, I have NOT added a new compiled .dll because I do not have the ability to emulate your building conditions (Specifically, I was unable to determine how you have references set up in your choice of compiler.).