### PR TITLE
Garbage compactor fully stops working without power, fixes #2

### DIFF
--- a/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Building/Building_AlloySplitter.cs
+++ b/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Building/Building_AlloySplitter.cs
@@ -12,7 +12,6 @@ namespace VanillaRecyclingExpanded
     public class Building_AlloySplitter : Building
     {
         private CompSuperSimpleProcessor comp;
-        private CompPowerTrader powerTrader;
         public int tickCounter =0;
         public const int interval = 600;
         private Effecter operatingEffecter;
@@ -26,18 +25,6 @@ namespace VanillaRecyclingExpanded
         }
 
 
-
-        private CompPowerTrader PowerTrader
-        {
-            get
-            {
-                if (powerTrader == null)
-                {
-                    powerTrader = GetComp<CompPowerTrader>();
-                }
-                return powerTrader;
-            }
-        }
 
         public CompSuperSimpleProcessor Comp
         {
@@ -56,7 +43,7 @@ namespace VanillaRecyclingExpanded
         {
             base.Tick();
 
-            if (Comp?.Empty == true || !PowerTrader.PowerOn)
+            if (Comp?.Working != true)
             {
                 operatingEffecter?.Cleanup();
                 operatingEffecter = null;

--- a/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Building/Building_Compactor.cs
+++ b/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Building/Building_Compactor.cs
@@ -59,7 +59,7 @@ namespace VanillaRecyclingExpanded
         {
             base.Tick();
             
-            if (comp!=null&&!comp.Empty)
+            if (comp!=null&&comp.Working)
             {
                 tickCounter++;
                 if (this.IsHashIntervalTick(interval))
@@ -78,7 +78,7 @@ namespace VanillaRecyclingExpanded
             base.DrawAt(drawLoc, flip);
             var vector = DrawPos;
             vector.y += 6;
-            if (comp != null && !comp.Empty)
+            if (comp != null && comp.Working)
             {
                
                 float height = Mathf.Lerp(0, 0.5f, (float)tickCounter / 600);

--- a/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Comps/CompSuperSimpleProcessor.cs
+++ b/1.5/Source/VanillaRecyclingExpanded/VanillaRecyclingExpanded/Comps/CompSuperSimpleProcessor.cs
@@ -36,6 +36,8 @@ namespace VanillaRecyclingExpanded
         public float FillPercent => (float)base.TotalStackCount / (float)Props.stackLimit;
         private Graphic contentsGraphic;
 
+        public bool Working => !Empty && (powerComp == null || powerComp.PowerOn);
+
         public override void PostSpawnSetup(bool respawningAfterLoad)
         {
             if (!ModLister.CheckBiotech("Atomizer"))
@@ -230,7 +232,7 @@ namespace VanillaRecyclingExpanded
         public override void CompTick()
         {
             base.CompTick();
-            if (!base.Empty && powerComp.PowerOn)
+            if (Working)
             {
                 ticksAtomized++;
                 if (ticksAtomized >= TicksPerAtomize)
@@ -268,7 +270,7 @@ namespace VanillaRecyclingExpanded
                 taggedString += (string)("VRecyclingE_ContainedThings".Translate(Props.thingDef.label) + ": ") + base.TotalStackCount + " / " + Props.stackLimit;
                 taggedString += "\n" + "FinishesIn".Translate() + ": " + "PeriodDays".Translate(((float)TicksLeftUntilAllAtomized / 60000f).ToString("F1"));
                 taggedString += "\n" + "VRecyclingE_DurationUntilNextProcess".Translate(Props.results[0].thingResult, Props.results[0].count) + ": " + (TicksPerAtomize - ticksAtomized).ToStringTicksToPeriod();
-                if (!powerComp.PowerOn)
+                if (powerComp != null && !powerComp.PowerOn)
                 {
                     taggedString += " (" + "Paused".Translate().ToString().UncapitalizeFirst() + ")";
                 }


### PR DESCRIPTION
This should fix an issue where the garbage compactor keeps being animated and producing toxic gas while not powered (#2). Additionally, all buildings/comps should now work fine even if the power trader comp is removed from them (if missing power trader comp they'll work without power, allowing for their use by primitive styled mods).

For more technical details:
- Added `Working` property to `CompSuperSimpleProcessor` which returns true if it's not empty and either powered or has no power comp
- `CompSuperSimpleProcessor` now uses the property to check if it should work
  - No change in behavior besides working without power comp
- `Building_Compactor` now uses the property to check if it should spawn toxic gas and animate
  - Previously only check if not empty, now it won't animate and make toxic gas without power (unless missing power comp)
- `Building_AlloySplitter`, for code simplicity, now uses the property to check if it cleanup/setup the effecter
  - (Basically) no change in behavior besides working without power comp
  - It also means that the building class doesn't need to have a field for its own power comp (since it's checked in the processor comp), so it was removed
  - The only change here is if the `CompSuperSimpleProcessor` is missing - previously it would create the effecter, with this change it'll instead clean it up
    - Given that this building relies on that comp, it's unlikely this is ever going to be relevant